### PR TITLE
Change ver 1.4.1 references to 1.5.0

### DIFF
--- a/bandit/formatters/yaml.py
+++ b/bandit/formatters/yaml.py
@@ -64,7 +64,7 @@ This formatter outputs the issues in a yaml format.
       test_id: B506
       test_name: yaml_load
 
-.. versionadded:: 1.4.1
+.. versionadded:: 1.5.0
 
 """
 # Necessary for this formatter to work when imported on Python 2. Importing

--- a/bandit/plugins/django_sql_injection.py
+++ b/bandit/plugins/django_sql_injection.py
@@ -39,7 +39,7 @@ def django_extra_used(context):
      - https://docs.djangoproject.com/en/dev/topics/
         security/#sql-injection-protection
 
-    .. versionadded:: 1.4.1
+    .. versionadded:: 1.5.0
 
     """
     description = "Use of extra potential SQL attack vector."
@@ -102,7 +102,7 @@ def django_rawsql_used(context):
      - https://docs.djangoproject.com/en/dev/topics/
         security/#sql-injection-protection
 
-    .. versionadded:: 1.4.1
+    .. versionadded:: 1.5.0
 
     """
     description = "Use of RawSQL potential SQL attack vector."

--- a/bandit/plugins/django_xss.py
+++ b/bandit/plugins/django_xss.py
@@ -278,7 +278,7 @@ def django_mark_safe(context):
      - https://docs.djangoproject.com/en/dev/
         ref/utils/#django.utils.html.format_html
 
-    .. versionadded:: 1.4.1
+    .. versionadded:: 1.5.0
 
     """
     if context.is_module_imported_like('django.utils.safestring'):


### PR DESCRIPTION
There have been significant changes since the 1.4.0 release, so
I'd like the next release to be 1.5.0 instead of 1.4.1. This patch
replaces 1.4.1 references with 1.5.0.

Signed-off-by: Eric Brown <browne@vmware.com>